### PR TITLE
Properly handle arrays.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm lint
+      - run: npm run lint
       - run: npm test
 name: CI
 on:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node": ">=16"
   },
   "exports": {
-    "types": "./source/index.ts",
+    "types": "./build/index.d.ts",
     "import": "./build/index.js",
     "require": "./build/index.cjs"
   },
@@ -64,6 +64,6 @@
   },
   "sideEffects": false,
   "type": "module",
-  "types": "./source/index.ts",
+  "types": "./build/index.d.ts",
   "version": "0.0.0-semantic-release"
 }

--- a/source/create-input-mapper.ts
+++ b/source/create-input-mapper.ts
@@ -1,0 +1,31 @@
+type InputMapper = <Input extends object, Recursive extends boolean>(
+  input: Input,
+  recursive: Recursive,
+  // I really don't like this, but I can't think of a better way at the moment.
+  // Maybe if TypeScript had higher order types.
+) => {[Key in keyof Input]: any};
+
+type ValueMapper = <Value, Recursive extends boolean>(
+  value: Value,
+  recursive: Recursive,
+) => unknown;
+
+export default function createInputMapper(
+  valueMapper: ValueMapper,
+): InputMapper {
+  return function inputMapper<Input extends object, Recursive extends boolean>(
+    input: Input,
+    recursive: Recursive,
+  ) {
+    if (Array.isArray(input)) {
+      return input.map((value) => valueMapper(value, recursive));
+    }
+
+    const entries = Object.entries(input).map(([key, value]) => [
+      key,
+      valueMapper(value, recursive),
+    ]);
+
+    return Object.fromEntries(entries);
+  };
+}

--- a/source/null-to-undefined.ts
+++ b/source/null-to-undefined.ts
@@ -1,3 +1,5 @@
+import createInputMapper from './create-input-mapper.js';
+
 type TrimNull<Input, Recursive extends boolean> = null extends Input
   ?
       | Exclude<
@@ -37,6 +39,18 @@ export type NullToUndefined<
   [Key in keyof Input]: TrimNull<Input[Key], Recursive>;
 };
 
+const inputMapper = createInputMapper((input, recursive) => {
+  if (input === null) {
+    return undefined;
+  }
+
+  if (!recursive || typeof input !== 'object') {
+    return input;
+  }
+
+  return inputMapper(input, true);
+});
+
 /**
  * Convert the null properties of an object to undefined.
  *
@@ -61,16 +75,7 @@ function nullToUndefined<Input extends object>(
     throw new TypeError('"input" must be an object.');
   }
 
-  const entries = Object.entries(input).map(([key, value]) => [
-    key,
-    value === null
-      ? undefined
-      : recursive && typeof value === 'object'
-      ? nullToUndefined(value, true)
-      : value,
-  ]);
-
-  return Object.fromEntries(entries);
+  return inputMapper(input, recursive);
 }
 
 export default nullToUndefined;

--- a/test/null-to-undefined.test.ts
+++ b/test/null-to-undefined.test.ts
@@ -211,4 +211,13 @@ describe('nullToUndefined', () => {
     );
     expect(output[1].oneMore).toBeUndefined();
   });
+
+  it('works for arrays in an object (recursively).', () => {
+    const input = {foo: [{bar: 1}, {bar: 2}, {bar: null}]};
+    const output = nullToUndefined(input, true);
+    expect(output.foo.length).toBe(3);
+    expect(output.foo[0]?.bar).toEqual(input.foo[0]?.bar);
+    expect(output.foo[1]?.bar).toEqual(input.foo[1]?.bar);
+    expect(output.foo[2]?.bar).toBeUndefined();
+  });
 });

--- a/test/undefined-to-null.test.ts
+++ b/test/undefined-to-null.test.ts
@@ -216,4 +216,13 @@ describe('undefinedToNull', () => {
     );
     expect(output[1].oneMore).toBeNull();
   });
+
+  it('works for arrays in an object (recursively).', () => {
+    const input = {foo: [{bar: 1}, {bar: 2}, {bar: undefined}]};
+    const output = undefinedToNull(input, true);
+    expect(output.foo.length).toBe(3);
+    expect(output.foo[0]?.bar).toEqual(input.foo[0]?.bar);
+    expect(output.foo[1]?.bar).toEqual(input.foo[1]?.bar);
+    expect(output.foo[2]?.bar).toBeNull();
+  });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,6 +2,7 @@ import {defineConfig} from 'tsup';
 
 export default defineConfig({
   clean: true,
+  dts: true,
   entry: ['source/index.ts'],
   format: ['cjs', 'esm'],
   outDir: 'build',


### PR DESCRIPTION
Hopefully the last time I have to fix this.  Before it was converting arrays to objects with numeric keys, which looks like it works until you actually have to use array-specific methods.  Introduces some `any` magic, so also builds a `.d.ts` and points to that for types so we can maybe pretend it's not held together with Silly Putty.